### PR TITLE
PKG-9154: Version update 0.2.1.post1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ test:
     - geomet.wkt
   requires:
     - pip
-    - pytest
   commands:
     - geomet -h
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,50 @@
 {% set name = "geomet" %}
-{% set version = "1.0.0" %}
+{% set version = "0.2.1.post1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0020a4426469934fb58f541cdc23f27c0c0fbbb3d003ee2cb76bb7ffa96a7506
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 91d754f7c298cbfcabd3befdb69c641c27fe75e808b27aa55028605761d17e95
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true # [py<34]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - geomet = geomet.tool:cli
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
   run:
-    - python >=3.6
+    - python
     - six
     - click
 
 test:
+  # NOTE: No tests in the package
   imports:
     - geomet
+    - geomet.tool
+    - geomet.util
+    - geomet.wkb
+    - geomet.wkt
+  requires:
+    - pip
+    - pytest
   commands:
     - geomet -h
+    - pip check
 
 about:
   home: https://github.com/geomet/geomet
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
   summary: GeoMet - Convert GeoJSON to WKT/WKB, and vice versa
   description: |
@@ -46,6 +57,7 @@ about:
     GeoMet is intended to cover all common use cases for dealing with 2D,
     3D, and 4D geometries (including 'Z', 'M', and 'ZM').
   dev_url: https://github.com/geomet/geomet
+  doc_url: https://github.com/geomet/geomet
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
geomet 0.2.1.post1

**Destination channel:** defaults

**NOTE 1:** This feedstock was never published in main channel. Although it might seem this PR is about version _downgrade_, it's about deployment a version actually needed by other package.

**NOTE 2**: _tests_ folder in dev repo but not in the package, hence no _pytest_ trigger in the recipe

### Links

- [PKG-9154](https://anaconda.atlassian.net/browse/PKG-9154)
- dev_url: https://github.com/geomet/geomet/tree/0.2.1
- conda_forge: https://github.com/conda-forge/geomet-feedstock/tree/main (latest version)
- pypi: https://pypi.org/project/geomet/0.2.1.post1/

### Explanation of changes:
- Version update to 0.2.1.post1


[PKG-9154]: https://anaconda.atlassian.net/browse/PKG-9154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ